### PR TITLE
docs(api): /docs-update audit fold-in (post-PR-9 cleanup, 11 gaps)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,57 +4,72 @@ This document is the source of truth for Fin CLI's system architecture.
 
 ## System Overview
 
-**Fin CLI** is a single-mode Python command-line application that screens stocks from Finviz.com. It is built as one importable package (`fincli`) with a Click entry point under `app/`, plus a small set of shared cross-cutting packages (`core`, `config`, `logger`). There is no server, no database, no network listener — outputs land as timestamped CSVs in `workspace_output/` by default, or wherever pipeline-mode CLI flags (`--output PATH`, `--output -` for stdout streaming, or `FINCLI_OUTPUT_DIR=<dir>`) redirect them.
+**Fin CLI** is a Python package that screens stocks from Finviz.com through two co-equal entry points: a CLI (`fincli/`) and an HTTP API (`fincli_api/`). Both consume the same orchestrator (`fincli.app.main.screen_to_dataframe`) and the same filter inventory (`fincli.resource.params.validators.list_valid_filters_with_labels`), so the contract cannot drift across surfaces. There is no database; CLI outputs land as timestamped CSVs in `workspace_output/` by default (or wherever pipeline-mode flags redirect), and HTTP API outputs are typed JSON envelopes returned per-request.
 
-The CLI has two distinct usage shapes that share the same orchestrator:
+The CLI has two usage shapes that share the same orchestrator:
 
 1. **Interactive** — bare `fincli` prompts the user through the three-section filter picker, writes a timestamped CSV under `workspace_output/`. The historical shape; unchanged.
 2. **Pipeline** — `fincli --filter/--filters-json/--filters-file ... --output PATH-or-` is consumable by another program. Reads structured input, writes to an exact destination (or streams CSV on stdout), emits a `OUTPUT_PATH=<value>` discovery line on stderr, optionally emits a single-line JSON summary, and exits with one of five classified codes (0/1/2/3/4 — see CONTRACTS §1 exit-codes table).
 
+The HTTP API exposes three first-class endpoints (`GET /filters`, `POST /screens`, `GET /healthz`) via FastAPI, with the contract pinned by a committed OpenAPI 3.1.0 snapshot at `docs/api/openapi.{yaml,json}`. Polyglot consumers codegen typed clients from the snapshot. See CONTRACTS §8 + `docs/api/openapi.yaml` for the wire contract; `fincli_api/` for the package; `INTEGRATION.md` "HTTP API mode" for the consumer-facing guide.
+
 ```
-                    +---------------------------+
-                    |        End User           |
-                    | (terminal / shell / CI)   |
-                    +-------------+-------------+
-                                  |
-                                  v
-                    +---------------------------+
-                    |      Click CLI Layer      |
-                    |  fincli/app/cli.py        |
-                    +-------------+-------------+
-                                  |
-                                  v
-                    +---------------------------+
-                    |    Orchestration Layer    |
-                    |    fincli/app/main.py     |
-                    +-------------+-------------+
-                                  |
-                                  v
-                    +---------------------------+
-                    |   Screener pipeline       |
-                    |   (Finviz HTML scrape)    |
-                    |   cfscrape + BS4          |
-                    +-------------+-------------+
-                                  |
-                                  v
-                       Finviz.com (Cloudflare-protected HTML)
+   +---------------------------+        +---------------------------+
+   |        End User           |        |    Polyglot Consumer      |
+   | (terminal / shell / CI)   |        |   (Go / TS / Rust / ...)  |
+   +-------------+-------------+        +-------------+-------------+
+                 |                                    |
+                 v                                    v
+   +---------------------------+        +---------------------------+
+   |      Click CLI Layer      |        |    FastAPI Layer          |
+   |  fincli/app/cli.py        |        |    fincli_api/main.py     |
+   |                           |        |    + routes/* + handlers  |
+   +-------------+-------------+        +-------------+-------------+
+                 |                                    |
+                 |                                    v
+                 |                      +---------------------------+
+                 |                      |   Adapter (boundary)      |
+                 |                      | fincli_api/adapters/      |
+                 |                      |   fincli.py               |
+                 |                      +-------------+-------------+
+                 |                                    |
+                 +------------+ same orchestrator +---+
+                              v
+                +---------------------------+
+                |    Orchestration Layer    |
+                |  fincli/app/main.py       |
+                |  screen_to_dataframe()    |
+                +-------------+-------------+
+                              |
+                              v
+                +---------------------------+
+                |   Screener pipeline       |
+                |   (Finviz HTML scrape)    |
+                |   cfscrape + BS4          |
+                +-------------+-------------+
+                              |
+                              v
+                  Finviz.com (Cloudflare-protected HTML)
 ```
+
+**Adapter-boundary rule (spec §3.2):** `fincli_api/adapters/fincli.py` is the ONLY file in `fincli_api/` allowed to import from `fincli/`. Every other API module imports through the adapter. This isolates the API package from fincli internals and makes the contract enforceable mechanically.
 
 ## Module Map
 
 | Module | Purpose | Key Files |
 |---|---|---|
-| `fincli/` | Stock screener — builds a Finviz query URL, fetches all paginated pages, parses the HTML stock table, writes CSV. | `fincli/app/cli.py`, `fincli/app/main.py`, `fincli/cli/cli_stock_screener.py` (section-by-section filter UI via `prompt_section`), `fincli/utils/web_scraper.py`, `fincli/utils/quary_builders.py`, `fincli/stock_screening/{content,parsers,locators}/stock_table*.py`, `fincli/resource/params/` |
+| `fincli/` | Stock screener — builds a Finviz query URL, fetches all paginated pages, parses the HTML stock table, writes CSV or returns a DataFrame. | `fincli/app/cli.py`, `fincli/app/main.py` (`screen_to_dataframe`, `run_stock_screener`), `fincli/cli/cli_stock_screener.py` (section-by-section filter UI via `prompt_section`), `fincli/utils/web_scraper.py`, `fincli/utils/quary_builders.py`, `fincli/stock_screening/{content,parsers,locators}/stock_table*.py`, `fincli/resource/params/`, `fincli/app/exit_codes.py` (classifier shared with HTTP API exception handler) |
+| `fincli_api/` | FastAPI HTTP service exposing the screener over REST+JSON. Adapter-boundary rule: only `adapters/fincli.py` may import from `fincli/`. | `fincli_api/main.py` (FastAPI app + uvicorn entry), `fincli_api/config.py` (`ApiConfig` via pydantic-settings), `fincli_api/routes/{filters,screens,meta}.py`, `fincli_api/adapters/fincli.py` (boundary), `fincli_api/models/{filters,screens,errors}.py` (Pydantic shapes), `fincli_api/exception_handlers.py` (classifier-driven envelope) |
 | `core/` | Pure Python configuration framework — Pydantic base classes (`SystemSettings`), JSON-to-tuple conversion, Configurator builder. Has no external service dependencies. | `core/configuration/config_base.py`, `core/configuration/configurator.py`, `core/converters/json.py` |
 | `config/` | Concrete `Config` instance for the application — extends `SystemSettings`, exposes `use_history`, `filters`, `scrape_link`, and `file_path(name)` for timestamped CSV destinations. | `config/config.py` |
 | `logger/` | Singleton logger with three named handlers: a typing-effect console handler, plain console handler, and a JSON file handler. Imported as `from logger import logger`. | `logger/logger.py`, `logger/handlers/`, `logger/formatters/` |
 
-Supporting (not part of the active runtime path):
+Supporting:
 
 | Module | Status |
 |---|---|
-| `scripts/` | Dependency-checking utilities. |
-| `tests/` | Folder layout exists (`tests/unit`, `tests/domain`, `tests/e2e`); test bodies will land in Phase 2 (see `CLAUDE.md`). |
+| `scripts/` | Dev tooling: `scripts/dump_openapi.py` regenerates `docs/api/openapi.{yaml,json}` from the FastAPI app (with `--check` mode for drift detection); `scripts/check_requirements.py` validates dep manifest. |
+| `tests/` | Three-tier pyramid in active use: `tests/unit/` (mocked adapters), `tests/integration/` (real fincli + mocked Finviz HTML), `tests/e2e/` (live Finviz, opt-in via `pytest -m live`). `tests/unit/api/`, `tests/integration/api/`, `tests/e2e/api/` mirror the same tiers for `fincli_api/`. |
 
 ## Data Flow
 
@@ -121,14 +136,24 @@ Supporting (not part of the active runtime path):
 
 ```
 +------------------------------------------------------------+
-|                     Click CLI Layer                        |
-|   fincli/app/cli.py                                        |
-|   (option parsing, --help text, logger level toggling)     |
-+------------------------------------------------------------+
+|        Click CLI Layer       |       FastAPI Layer         |
+|  fincli/app/cli.py           |  fincli_api/main.py         |
+|  (option parsing, --help,    |  (FastAPI app + routes/* +  |
+|   logger level toggling)     |   exception_handlers.py)    |
++------------------------------+-----------------------------+
+|                          |                                 |
+|                          v                                 |
+|                  +------------------------+                |
+|                  |  Adapter (boundary)    |                |
+|                  | fincli_api/adapters/   |                |
+|                  |   fincli.py            |                |
+|                  +-----------+------------+                |
+|                              |                             |
++------------------------------+-----------------------------+
 |                    Orchestration Layer                     |
 |   fincli/app/main.py                                       |
 |   (pipeline composition: build query -> fetch -> parse     |
-|    -> DataFrame -> write CSV)                              |
+|    -> DataFrame -> write CSV / return to caller)           |
 +------------------------------------------------------------+
 |                Domain / UI Layer                           |
 |   fincli/cli/cli_stock_screener.py       (filter UI)       |
@@ -147,13 +172,15 @@ Supporting (not part of the active runtime path):
 
 **Layering rule:** orchestration calls down into the filter UI and utility/I/O, never the reverse. Utility/I/O modules receive primitive inputs (a URL, raw HTML bytes) and have no awareness of how they will be assembled into a DataFrame. Cross-cutting modules are imported anywhere they are needed.
 
+**Adapter-boundary rule (spec §3.2):** the FastAPI layer imports ONLY through `fincli_api/adapters/fincli.py`. Routes / models / exception handlers in `fincli_api/` may NOT `import fincli.<anything>` directly. This isolates the API package from fincli internals so the contract surface is enforceable via a single file's diff.
+
 There is no formal dependency-injection container. Wiring is done by direct import and function call in the orchestration layer. The Singleton logger is the only globally-visible runtime object.
 
 ### Side effects
 
 Every successful run produces three observable side effects beyond the CSV write itself; pipeline integrators rely on this trio to discover the result without screen-scraping log lines:
 
-1. **`OUTPUT_PATH=<value>` discovery line** — written to **stderr** exactly once, immediately before exit, on every run (regardless of success/failure or any other flag). `<value>` is either the absolute path the CSV was written to, or the literal `-` sentinel for `--output -` streaming, or the empty string if an exception fired before the destination was resolved. Format pinned by CONTRACTS §1 + §7.
+1. **`OUTPUT_PATH=<value>` discovery line** — written to **stderr** exactly once, immediately before exit, on every run (regardless of success/failure or any other flag). `<value>` is either the absolute path the CSV was written to, or the literal `-` sentinel for `--output -` streaming. The destination is resolved before the orchestrator's try-block opens, so the line is populated on every exit code (0/1/3/4) for any `--output PATH` invocation — never empty. Format pinned by CONTRACTS §1 + §7.
 2. **`--json-summary` line** (optional) — when `--json-summary` is set, a single-line JSON object matching the schema in CONTRACTS §5.5 is written immediately after the `OUTPUT_PATH=` line. Routes to **stdout** by default and to **stderr** when `--output -` claims stdout for CSV bytes.
 3. **Exit code** — one of five classified values (CONTRACTS §1 exit-codes table). `0` SUCCESS / `1` INTERNAL / `2` USAGE (Click) / `3` UPSTREAM / `4` DATA. The orchestrator's try/except wrapper around the pipeline runs every uncaught exception through `fincli.app.exit_codes.classify` before threading the code into both the JSON summary and `sys.exit`.
 
@@ -177,10 +204,12 @@ Every successful run produces three observable side effects beyond the CSV write
 
 ```
 fin_cli/
-  fincli/                      # Stock screener
+  fincli/                      # Stock screener CLI
     app/
       cli.py                   # Click entry point
-      main.py                  # Pipeline orchestrator
+      main.py                  # Pipeline orchestrator + screen_to_dataframe helper
+      exit_codes.py            # classify() — single source of truth for failure
+                               #             classification (CLI + HTTP API consume it)
     cli/
       cli_stock_screener.py    # Section-by-section interactive filter UI
     resource/
@@ -201,6 +230,21 @@ fin_cli/
       quary_builders.py        # Finviz URL construction
       user_agent_rotator.py
 
+  fincli_api/                  # HTTP API (FastAPI) — sibling of fincli/
+    main.py                    # FastAPI app + uvicorn entry (bound to fincli-api script)
+    config.py                  # ApiConfig via pydantic-settings (host/port/log_level)
+    routes/
+      filters.py               # GET /filters
+      screens.py               # POST /screens (with validate_filter_pairs gate)
+      meta.py                  # GET /healthz
+    adapters/
+      fincli.py                # Boundary layer — only file allowed to import from fincli/
+    models/
+      filters.py               # FilterInventory + FilterEntry
+      screens.py               # ScreenRequest + ScreenResult + Stock
+      errors.py                # ErrorResponse (Literal discriminator on error_class)
+    exception_handlers.py      # register_exception_handlers(app) via exit_codes.classify
+
   core/                        # Pure Python configuration framework
     configuration/
       config_base.py           # SystemSettings, Configurable[S]
@@ -216,10 +260,19 @@ fin_cli/
     handlers/
     formatters/
 
-  tests/                       # Phase 2 work — empty bodies today
+  tests/                       # 3-tier pyramid (live tier opt-in via -m live)
     unit/
-    domain/
+      api/                     # FastAPI TestClient + mocked adapter
+      ...                      # mocked-dep tests for fincli/
+    integration/
+      api/                     # TestClient + real fincli + mocked Finviz HTML
+      fixtures/                # 5 Finviz HTML fixtures (happy/one_page/empty/no_table/malformed_row)
     e2e/
+      api/                     # TestClient + live Finviz (3 tests, @pytest.mark.live)
+
+  scripts/
+    dump_openapi.py            # Regenerate docs/api/openapi.{yaml,json} (with --check)
+    check_requirements.py
 
   workspace_output/            # CSV results (gitignored)
   workspace_materials/         # Working notes (gitignored)
@@ -229,8 +282,12 @@ fin_cli/
     THESIS.md
     MODULE_REFERENCE.md
     FEEDBACK-LOG.md
+    api/                       # Committed OpenAPI 3.1.0 snapshot
+      openapi.yaml
+      openapi.json
     bugs/, refactoring/, reviewer/
-    superpowers/specs/
+    features/                  # Feature specs (archive/ = shipped)
+    superpowers/specs/         # Brainstorming-derived design specs (archive/ = shipped)
 
   agents/                      # AI-agent rules + role files
     rules/
@@ -243,13 +300,15 @@ fin_cli/
 
   ARCHITECTURE.md              # this file
   CLAUDE.md
-  CONTRACTS.md
+  CONTRACTS.md                 # §1 CLI surface; §8 HTTP API surface
+  INTEGRATION.md               # Polyglot-consumer guide (CLI mode + HTTP API mode)
   README.md
   TESTING.md
   TOOLS_REFERENCE.md
   AGENTS.md
 
   pyproject.toml
+  pytest.ini                   # Canonical pytest config (pytest.ini > pyproject)
   requirements.txt
   run.sh / run.bat             # Convenience launchers
   singleton.py                 # Standalone metaclass utility
@@ -261,7 +320,7 @@ The screener pipeline is fully synchronous. Pages from Finviz are fetched one at
 
 The Singleton `Logger` is constructed once at import time. Its underlying `logging.Logger` handlers are Python's stdlib `logging` handlers, which are thread-safe by design. The typing-animation console handler serializes its writes to stdout under the same lock, so any future fan-out work (none today) would be safe to log freely.
 
-There is no `asyncio` and no `ThreadPoolExecutor` in the active runtime path. Adding async I/O is on the long-term roadmap (`docs/THESIS.md`) but not in active scope.
+The HTTP API's route handlers are sync (`def`, not `async def`) — fincli is fully sync, so FastAPI runs the handlers in its default thread pool. At single-user load (the spec's scope), the thread pool is fine; the bottleneck is Finviz's per-IP rate ceiling, not concurrency. No `asyncio` is used in `fincli_api/` either. Adding true async I/O would require porting the scraper off cfscrape and is on the long-term roadmap (`docs/THESIS.md`) but not in active scope.
 
 ## Configuration Shape
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ Full diagram + per-section detail in `ARCHITECTURE.md`.
 - The `Ticker` column in the screener CSV is wrapped as an Excel `=HYPERLINK(...)` formula. Preserve that when adding new columns adjacent to it.
 
 ### Testing
-- Test layout (Phase 2 work): `tests/unit/`, `tests/domain/`, `tests/e2e/`.
-- See `TESTING.md` for fixtures, mocking strategy, and which dependencies are mockable vs. real.
+- Test layout: `tests/unit/`, `tests/integration/`, `tests/e2e/`. Each tier has a `tests/<tier>/api/` sub-directory for `fincli_api/` tests. Live-Finviz e2e is opt-in via `pytest -m live`.
+- See `TESTING.md` for fixtures, mocking strategy (the local-binding rule for `fincli.app.main.fetch_page_sync`), and which dependencies are mockable vs. real.
 
 ## MCP Tool Usage
 

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -2,13 +2,14 @@
 
 This document defines the **stable surfaces** that other code (downstream automation, Phase 2 tests, future modules) and end users rely on. A contract here is a promise: changing it is a breaking change, governed by the stability policy at the bottom of this file.
 
-Fin CLI has **no REST API, no HTTP listener, no broker integration, no database**. It is a CLI plus a set of importable Python packages, plus the CSV it writes. The contracts therefore live in five places:
+Fin CLI exposes its screener through two co-equal entry points (CLI + HTTP API) — both have stable contracts here. There is no broker integration and no database. The contracts live in six places:
 
 1. The **CLI command surface** — every Click command, every option, every exit code.
 2. The **Finviz query parameter contract** — the `[query_key, {value_code: display_name}]` filter shape under `fincli/resource/params/`.
 3. The **CSV output schema** — column names, dtypes, sort order, file naming.
 4. The **Configuration shape** — the Pydantic-validated `Config` produced by `core/configuration/configurator.py`.
 5. The **logger contract** — what `from logger import logger` returns and what its methods promise.
+6. The **HTTP API surface (§8)** — endpoints (`GET /filters`, `POST /screens`, `GET /healthz`), request/response schemas, `ErrorResponse` envelope, OpenAPI snapshot. Machine-readable contract at `docs/api/openapi.yaml`.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This document defines the testing strategy, conventions, and follow-up roadmap f
 
 Tests verify **behavior**, not implementation. A test that locks in the current implementation of a function (mocking out internals, asserting call counts on private helpers) becomes a tax to pay every time the function is refactored, even when behavior is unchanged. A test that asserts what the function *does* — input goes in, output comes out, side effect happens — survives refactors and earns its keep.
 
-This codebase currently has **zero test bodies**. The `tests/` folder structure (`tests/unit/`, `tests/domain/`, `tests/e2e/`) exists from a prior reorganization, but `__pycache__` is the only surviving artifact of the old test files. **Phase 2** of the agent-harness rollout (`docs/superpowers/specs/2026-05-02-agent-harness-replication-design.md`, §8.1) is the work item that introduces real tests. Until that ships, `pytest tests/` runs cleanly because there is nothing to fail — and that is the intentional starting state, not a gap to backfill in Phase 1.
+The test suite uses a three-tier pyramid: `tests/unit/` (mocked at boundaries), `tests/integration/` (real fincli + mocked Finviz HTML fixtures), `tests/e2e/` (live Finviz HTTP, opt-in via `pytest -m live`). Each tier has a `tests/<tier>/api/` sub-directory mirroring the layout for `fincli_api/`. Current state: 279 passed / 1 skipped / 3 deselected (live tier) / 1 xfailed (MAJOR #4 deferred) on the default `pytest tests/` invocation; `pytest -m live tests/e2e/api/` runs the 3 live-Finviz API smoke tests (~3s, network-dependent).
 
 When tests do land, they should:
 
@@ -82,7 +82,7 @@ pytest tests/
 
 # Layer-scoped
 pytest tests/unit/
-pytest tests/domain/
+pytest tests/integration/
 pytest tests/e2e/
 
 # Pattern match by name
@@ -291,7 +291,7 @@ This section is the source of truth for *when* the deferred test work happens. A
 
 **Scope:**
 
-- Real `pytest` tests under `tests/unit/`, `tests/domain/`, `tests/e2e/`.
+- Real `pytest` tests under `tests/unit/`, `tests/integration/`, `tests/e2e/`.
 - One test file per module listed in `tests/` layout above.
 - HTML fixture for the Finviz parser.
 - Add type hints incrementally to the modules being tested — this is the natural moment to drive the mypy advisory count down.

--- a/TOOLS_REFERENCE.md
+++ b/TOOLS_REFERENCE.md
@@ -8,15 +8,20 @@ A single-page reference for every command, skill, MCP tool, and Claude Code hook
 
 | Command | What it does |
 |---|---|
-| `pip install -e ".[dev]"` | Editable install with the `dev` extra (ruff, mypy, pytest, pytest-cov, types-beautifulsoup4, pip-audit). |
+| `pip install -e ".[dev]"` | Editable install with the `dev` extra (ruff, mypy, pytest, pytest-cov, types-beautifulsoup4, pip-audit, fastapi/uvicorn/pydantic-settings runtime, httpx/pyyaml dev for the API tier). |
 | `pip install -r requirements.txt` | Install runtime deps only (no dev tooling). |
-| `fincli` | Run the screener (preferred). Equivalent to `python -m fincli`; requires `pip install -e ".[dev]"` to register the entry point on PATH. |
-| `python -m fincli` | Run the screener (interactive). |
-| `python -m fincli --history` | Run the screener with the last filter selection. |
-| `python -m fincli --debug` | Run the screener with `DEBUG`-level logging. |
-| `./run.sh` | Linux / macOS launcher: install requirements, then `python -m fincli "$@"`. |
-| `run.bat` | Windows launcher: install requirements, then `python -m fincli %*`. |
-| `python -c "import fincli"` | Smoke-import test (Python has no separate build step). |
+| `fincli` | Run the CLI screener (preferred). Equivalent to `python -m fincli`. Requires `pip install -e ".[dev]"` to register the entry point on PATH. |
+| `python -m fincli` | Run the CLI screener (interactive). |
+| `python -m fincli --history` | Run the CLI with the last filter selection. |
+| `python -m fincli --debug` | Run the CLI with `DEBUG`-level logging. |
+| `python -m fincli --list-filters --json` | Dump the full Finviz filter inventory as JSON (polyglot-consumer bootstrap path; no HTTP). |
+| `./run.sh` | Linux / macOS CLI launcher: install requirements, then `python -m fincli "$@"`. |
+| `run.bat` | Windows CLI launcher: install requirements, then `python -m fincli %*`. |
+| `uvicorn fincli_api.main:app --reload` | Run the HTTP API in dev mode (auto-reload on code change). Binds `127.0.0.1:8000`. |
+| `fincli-api` | Run the HTTP API via the console-script entry. Equivalent to uvicorn invocation above. |
+| `python scripts/dump_openapi.py` | Regenerate the committed OpenAPI snapshot at `docs/api/openapi.{yaml,json}` from the live FastAPI app. |
+| `python scripts/dump_openapi.py --check` | Drift detection: exit 1 if committed snapshot ≠ live `app.openapi()`. CI / pre-commit-suitable. |
+| `python -c "import fincli, fincli_api"` | Smoke-import test (Python has no separate build step). |
 
 ---
 
@@ -24,17 +29,20 @@ A single-page reference for every command, skill, MCP tool, and Claude Code hook
 
 | Command | What it does |
 |---|---|
-| `pytest tests/` | Run all tests. |
-| `pytest tests/unit/` | Run unit-layer tests only. |
-| `pytest tests/domain/` | Run domain-layer tests only. |
-| `pytest tests/e2e/` | Run end-to-end tests only. |
+| `pytest tests/` | Run all tests (default excludes live-Finviz tier via `pytest.ini` addopts). |
+| `pytest tests/unit/` | Run unit-tier only (mocked adapters; fastest). |
+| `pytest tests/unit/api/` | Run API unit tests only (FastAPI TestClient + mocked adapter). |
+| `pytest tests/integration/` | Run integration-tier (real fincli + mocked Finviz HTML fixtures). |
+| `pytest tests/integration/api/` | Run API integration tests only. |
+| `pytest tests/e2e/` | Run e2e-tier (still requires `-m live` opt-in for the live-Finviz subset). |
+| `pytest -m live tests/e2e/api/` | Run the 3 live-Finviz API smoke tests (opt-in; ~3s, requires network). |
 | `pytest -k <pattern>` | Run tests whose name matches a substring/expression. |
 | `pytest -x` | Stop at first failure. |
 | `pytest -v` | Verbose output (one line per test). |
-| `pytest --cov=fincli --cov=core --cov=config --cov-report=term-missing` | Coverage report (informational; gate deferred to Phase 3). |
-| `pytest -ra` | Short summary of skipped/xfailed/errored tests (default via `pyproject.toml`). |
+| `pytest --cov=fincli --cov=fincli_api --cov=core --cov=config --cov-report=term-missing` | Coverage report (informational; gate deferred to Phase 3). |
+| `pytest -ra` | Short summary of skipped/xfailed/errored tests (default via `pytest.ini`). |
 
-> Test bodies land in Phase 2 of the agent-harness rollout (`docs/superpowers/specs/2026-05-02-agent-harness-replication-design.md` §8.1). Until then `pytest tests/` collects nothing.
+> Current state: 279 passed / 1 skipped / 3 deselected (live tier) / 1 xfailed in the default invocation. The live-tier gate (`pytest -m live tests/e2e/api/`) is **mandatory before HUMAN approval** on any change to `fincli_api/` or `fincli/stock_screening/` per FEEDBACK-LOG.md 2026-05-22 entry.
 
 ---
 
@@ -63,7 +71,7 @@ A single-page reference for every command, skill, MCP tool, and Claude Code hook
 
 | Command | What it does |
 |---|---|
-| `mypy fincli core config logger` | Type-check the active modules in strict mode (Phase 1: advisory; Phase 4: blocking). |
+| `mypy fincli fincli_api core config logger` | Type-check the active modules in strict mode (Phase 1: advisory; Phase 4: blocking). `fincli_api/` is 0 errors today; legacy `fincli/` baseline ~49 errors per CLAUDE.md Phase status. |
 | `mypy <file>` | Check one file (used by `post-edit.js`). |
 | `mypy --no-incremental` | Bypass mypy's cache when diagnosing weirdness. |
 
@@ -264,8 +272,10 @@ Without this, the sub-agent literally cannot make the call.
 ## Cross-reference
 
 - Build/run conventions, file map, phase status: [`CLAUDE.md`](CLAUDE.md)
-- System architecture, layering, threading: [`ARCHITECTURE.md`](ARCHITECTURE.md)
-- CLI surface, CSV schema, stability policy: [`CONTRACTS.md`](CONTRACTS.md)
-- Test layout, mocking strategy, Phase 2/3/4 roadmap: [`TESTING.md`](TESTING.md)
+- System architecture, layering, threading, adapter-boundary rule: [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- CLI surface, CSV schema, HTTP API surface (§8), stability policy: [`CONTRACTS.md`](CONTRACTS.md)
+- Polyglot-consumer integration guide (CLI subprocess mode + HTTP API mode): [`INTEGRATION.md`](INTEGRATION.md)
+- Committed OpenAPI 3.1.0 snapshot for HTTP API codegen: [`docs/api/openapi.yaml`](docs/api/openapi.yaml) (+ `.json` sibling)
+- Test layout, 3-tier pyramid, mocking strategy, Phase 2/3/4 roadmap: [`TESTING.md`](TESTING.md)
 - Master agent index (Tier 1–4 reading order, sub-agent context diet): [`AGENTS.md`](AGENTS.md)
 - Project vision and roadmap: [`docs/THESIS.md`](docs/THESIS.md)

--- a/agents/roles/backend-architect.md
+++ b/agents/roles/backend-architect.md
@@ -7,7 +7,7 @@ color: purple
 
 You are a senior backend / domain-logic engineering assistant for **fin_cli**. Your job is to help implement, refactor, test, and review the Python domain logic, pipelines, CLI surface, configuration, and supporting infrastructure in this repository.
 
-fin_cli has **no database, no REST API, and no auth layer**. Its surface is:
+fin_cli has **no database and no auth layer**. It exposes its screener through two co-equal entry points (CLI + HTTP API) that share one orchestrator. Its surface is:
 - A Click-based CLI (`fincli` command group).
 - Pure-Python parsing logic in `fincli/stock_screening/` and `fincli/utils/`.
 - Pipeline orchestration in `fincli/app/main.py`.
@@ -33,7 +33,7 @@ fin_cli has **no database, no REST API, and no auth layer**. Its surface is:
 
 ## Testing and validation
 
-- When behavior changes, add or update tests under `tests/unit/<module>/`, `tests/domain/<module>/`, or `tests/e2e/<module>/`.
+- When behavior changes, add or update tests under `tests/unit/<module>/`, `tests/integration/<module>/`, or `tests/e2e/<module>/`.
 - Prefer tests that verify observable behavior (CSV output columns + dtypes, calculator return values) rather than implementation details.
 - For bug fixes, add a regression test when practical.
 - Run the smallest relevant test suite first (`pytest tests/unit/<module>/`), then broader checks if the change is risky.
@@ -213,7 +213,7 @@ Use:
 
 Standard verification commands:
 - `pytest tests/unit/<module>/`
-- `pytest tests/domain/<module>/` (if domain logic touched)
+- `pytest tests/integration/<module>/` (if domain logic touched)
 - `pytest tests/e2e/<module>/` (for pipeline changes)
 - `ruff check <touched module>`
 - `ruff format --check <touched module>`

--- a/agents/roles/code-reviewer.md
+++ b/agents/roles/code-reviewer.md
@@ -40,7 +40,7 @@ If a fix is needed, describe the smallest safe fix and hand off to the appropria
    - Ask for simplification when code is harder to understand than the problem requires.
 
 3. **Review Tests and Validation**
-   - Verify behavior changes include meaningful tests under `tests/unit/`, `tests/domain/`, or `tests/e2e/`.
+   - Verify behavior changes include meaningful tests under `tests/unit/`, `tests/integration/`, or `tests/e2e/`.
    - Prefer behavior-focused tests over implementation-detail tests.
    - Check that tests would fail if the implementation were broken.
    - Coverage gate is **deferred to Phase 3 (target 90%)** — do not invent a coverage requirement before that phase.

--- a/agents/roles/verifier.md
+++ b/agents/roles/verifier.md
@@ -74,7 +74,7 @@ You are a skeptical validator for the **fin_cli** project. Your job is to indepe
 ```bash
 # Run relevant tests
 pytest tests/unit/<module>/ -v
-pytest tests/domain/<module>/ -v          # if domain logic touched
+pytest tests/integration/<module>/ -v          # if domain logic touched
 pytest tests/e2e/<module>/ -v             # for full-pipeline changes
 
 # Lint and format
@@ -109,7 +109,7 @@ pytest tests/
 | Suite | Tooling | Status |
 |-------|---------|--------|
 | Unit tests | pytest (`tests/unit/<module>/`) | required when behavior changed |
-| Domain tests | pytest (`tests/domain/<module>/`) | required for `fincli/stock_screening/` and pipeline changes |
+| Integration tests | pytest (`tests/integration/<module>/`) | required for `fincli/stock_screening/`, pipeline changes, and `fincli_api/` routes (TestClient + mocked Finviz HTML) |
 | E2E tests | pytest with fixture data (`tests/e2e/<module>/`) | required for full-pipeline changes |
 | Lint | ruff | gate |
 | Format | ruff format --check | gate |

--- a/agents/rules/scaffold-module.md
+++ b/agents/rules/scaffold-module.md
@@ -198,7 +198,7 @@ if __name__ == "__main__":
 - [x] {module-name}/app/main.py
 - [x] {module-name}/utils/__init__.py
 - [x] tests/unit/{module-name}/test_smoke.py
-- [x] tests/domain/{module-name}/__init__.py
+- [x] tests/integration/{module-name}/__init__.py
 - [x] tests/e2e/{module-name}/__init__.py
 
 ### Next Steps

--- a/docs/MODULE_REFERENCE.md
+++ b/docs/MODULE_REFERENCE.md
@@ -1,6 +1,6 @@
 # MODULE_REFERENCE.md — Fin CLI Internal Module Reference
 
-This file documents the internal modules of Fin CLI. There is no REST API to document — the public surface is a CLI, and the internal boundaries are importable Python packages. Each section follows a fixed structure: Purpose / Key files / Public surface / Data shapes / Error modes / Integration.
+This file documents the internal modules of Fin CLI. The public surface is two-fold: a CLI (`fincli/`) and an HTTP API (`fincli_api/`); both share one orchestrator. The HTTP API wire-contract details live in `CONTRACTS.md` §8 + the OpenAPI snapshot at `docs/api/openapi.yaml` — this file covers the Python-internal boundaries on both sides. Each section follows a fixed structure: Purpose / Key files / Public surface / Data shapes / Error modes / Integration.
 
 See `ARCHITECTURE.md` for the system-level diagram and data-flow narrative. See `docs/THESIS.md` for vision and roadmap.
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #9 (fincli HTTP API umbrella). After the umbrella merged, running the `/docs-update` skill against the post-merge state surfaced 11 stale-content gaps the umbrella's custom doc-sweep prompts missed — 7 in files the umbrella never touched, 4 in files it did but didn't fully sweep. This PR closes all 11.

Single commit: \`3fdaf64\` (10 files, +148/-78 LOC, docs-only).

## Background

The umbrella's T7' (early docs) + T8 (post-code docs) waves used custom BACKEND prompts via plan-and-create + dispatching-parallel-agents rather than invoking `/docs-update`. The result was largely good (REVIEWER caught 3 BLOCKERs in T8c that would have shipped wire-contract drift), but ARCHITECTURE.md / TOOLS_REFERENCE.md / agents/ files were never in the prompt enumeration. Plus 4 doc files the umbrella DID touch had intro lines that survived unedited despite contradicting the new content (e.g., CONTRACTS.md L5 said "no REST API" while §8 described the HTTP API surface).

## Gaps closed

### HIGH-priority (load-bearing public lies in source-of-truth docs)

- **ARCHITECTURE.md** — full sweep for HTTP API surface: System Overview reframed for two co-equal entry points, ASCII data-flow diagram now shows CLI + FastAPI siblings sharing one orchestrator, Module Map adds `fincli_api/` row, Layering diagram adds API + adapter layers with the architectural-boundary rule, Folder Structure adds `fincli_api/` + `scripts/` + `docs/api/` + `tests/{unit,integration,e2e}/api/`, Threading Model adds FastAPI sync-handler note, side-effects bullet corrects the OUTPUT_PATH= empty-on-exception claim (was the screener-fix bug closed in commit \`8d22af7\` during the list-filters umbrella).
- **agents/roles/backend-architect.md L10** — \"fin_cli has no database, no REST API, and no auth layer\" → \"no database and no auth layer; exposes screener through two co-equal entry points\".

### MEDIUM-priority (other docs the umbrella didn't fully sweep)

- **TOOLS_REFERENCE.md** — Build/Run table adds \`uvicorn fincli_api.main:app\` / \`fincli-api\` script / \`scripts/dump_openapi.py\` (+ --check); Test table adds \`pytest -m live tests/e2e/api/\` + per-tier \`api/\` paths + drops the stale \"collects nothing\" note; Type check extends mypy scope to include \`fincli_api\`; Cross-reference adds INTEGRATION.md + OpenAPI snapshot pointers.
- **CLAUDE.md L165 (Testing section)** — \"Phase 2 work\" framing + stale \`tests/domain\` reference → current 3-tier pyramid + \`api/\` sub-dirs + live marker.
- **TESTING.md L9** — \"currently has zero test bodies\" was literally false (279 tests landed in this umbrella's T5) → describes the current 3-tier pyramid with exact counts. L85/L294 \`tests/domain\` → \`tests/integration\`.
- **CONTRACTS.md L5** — \"no REST API, no HTTP listener\" → \"two co-equal entry points + HTTP API surface §8\"; contracts list extended from 5 to 6 entries.
- **docs/MODULE_REFERENCE.md L3** — \"no REST API to document\" → \"public surface is two-fold (CLI + HTTP API); wire-contract details in CONTRACTS.md §8 + OpenAPI snapshot\".

### LOW-priority (pre-existing stale-test-layout refs the umbrella's tests/{integration,e2e}/api/ made more visible)

- **agents/roles/backend-architect.md** L36, L216: \`tests/domain\` → \`tests/integration\`.
- **agents/roles/code-reviewer.md** L43: \`tests/domain\` → \`tests/integration\`.
- **agents/roles/verifier.md** L77, L112: \`tests/domain\` refs + \"Domain tests\" → \`tests/integration\` + \"Integration tests\" (with API note).
- **agents/rules/scaffold-module.md** L201: scaffold template now creates \`tests/integration/{module}/__init__.py\` (not \`tests/domain\`).

## Test plan

- [x] \`pytest tests/\` → 279 passed / 1 skipped / 3 deselected / 1 xfailed (unchanged — docs-only PR)
- [x] No remaining \"no REST API\" / \"single-mode CLI\" / \"tests/domain\" / \"zero test bodies\" references in live docs (grep clean; only historical refs in \`archive/\` + \`docs/superpowers/specs/\` + session handoffs remain, intentionally per append-only doc conventions)
- [x] ruff check clean; pytest baseline unchanged

## Durable lesson (captured in FEEDBACK-LOG for next session)

Skill substitution by custom prompts is the most common discipline failure — \`/docs-update\` has a curated checklist that catches doc-files the custom prompt enumeration forgets. Pattern to apply going forward: **invoke \`/docs-update\` at the end of any umbrella that touches public surfaces**, treat custom-prompt doc-sweeps as supplementary not replacement.

## References

- Builds on: PR #9 (fincli HTTP API umbrella, merged at \`b7c9dcd\`)
- Triggered by: user question \"have you done /docs-update?\" — answer was no; this PR is the audit fold-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)