### PR TITLE
chore(parser): review follow-ups — empty-marker tightening, Link-anchor unification, ruff pin

### DIFF
--- a/fincli/stock_screening/content/stock_table.py
+++ b/fincli/stock_screening/content/stock_table.py
@@ -39,4 +39,4 @@ class StockTableScreeningContent:
             True when the empty-result marker element is present on the
             page, False otherwise.
         """
-        return self.soup.find(id=StockTableLocators.EMPTY_BODY_ID) is not None
+        return self.soup.find("table", id=StockTableLocators.EMPTY_BODY_ID) is not None

--- a/fincli/stock_screening/parsers/stock_table.py
+++ b/fincli/stock_screening/parsers/stock_table.py
@@ -71,8 +71,8 @@ class StockTableScreenerParser:
         """
         anchors = cells[1].find_all("a")
         if not anchors:
-            # No anchor at all: let `ticker_link`'s `.find("a")` raise the
-            # existing AttributeError contract instead of masking it here.
+            # No anchor at all: let `ticker_link` raise the existing
+            # AttributeError contract instead of masking it here.
             return cells[1].get_text(strip=True)
 
         last_anchor = anchors[-1]
@@ -86,12 +86,22 @@ class StockTableScreenerParser:
                 f"{href_ticker!r} (href={href!r}) — Finviz layout drift or "
                 "corrupted ticker data"
             )
+        # Not a dead cast: `anchors[-1]` is `Any` under the bs4 stubs, so
+        # `get_text()` returns `Any` and strict mypy needs the narrowing.
         return cast(str, text)
 
     @classmethod
     def ticker_link(cls, cells: list[Tag]) -> str:
+        """Return the canonical Finviz URL for the row's ticker cell.
+
+        Derived from the LAST anchor in the ticker cell — the same anchor
+        ``ticker_symbol`` validates text-vs-href agreement on — so the
+        emitted ``Link`` column can never come from a different element
+        than the validated symbol. (Both live-layout anchors share one
+        href today; this guards future drift.)
         """
-        Returns the ticker link.
-        """
-        link = cast(str, cast(Tag, cells[1].find("a")).get("href"))
+        # `None.get` preserves the pinned no-anchor failure contract:
+        # AttributeError, classified DATA=4 (same as the legacy `.find("a")`).
+        last_anchor = cells[1].find_all("a")[-1] if cells[1].find_all("a") else None
+        link = cast(str, cast(Tag, last_anchor).get("href"))
         return BASE_URL + link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.6",
+    # Pinned to one minor so `ruff format --check` output is stable across
+    # venv rebuilds: 0.16 began formatting Markdown code fences, and unpinned
+    # worktree venvs resolving different ruff minors made the same tree pass
+    # one gate run and fail the next (2026-08-12 burndown session).
+    "ruff>=0.16.2,<0.17",
     "mypy>=1.10",
     "pytest>=8",
     "pytest-cov>=5",

--- a/tests/unit/stock_screening/parsers/test_stock_table_parser.py
+++ b/tests/unit/stock_screening/parsers/test_stock_table_parser.py
@@ -112,6 +112,14 @@ def test_ticker_symbol_missing_t_param_raises_layout_error() -> None:
         StockTableScreenerParser.ticker_symbol(cells)
 
 
+def test_ticker_symbol_anchor_without_href_raises_layout_error() -> None:
+    """An anchor carrying no `href` attribute at all -> raise, never silently return."""
+    cells = _cells("<tr><td>1</td><td><a>AAPL</a></td></tr>")
+
+    with pytest.raises(ScreenerLayoutError):
+        StockTableScreenerParser.ticker_symbol(cells)
+
+
 def test_ticker_symbol_no_anchor_falls_back_to_cell_text() -> None:
     """No `<a>` in the cell: return the plain text rather than raising here.
 


### PR DESCRIPTION
Post-merge follow-ups from the PR #17/#18 reviewer verdicts (pre-approved: "do all the recommendation and post merge tasks"):

- **S1**: `has_empty_marker` → `find('table', id=...)` — only a genuine empty-state *table* counts as a legit zero-result marker.
- **S2**: `ticker_link` derives the `Link` URL from the same (last) anchor `ticker_symbol` validates — the emitted link can never come from a different element than the validated symbol. Pinned no-anchor AttributeError/DATA contract preserved (unit test still green).
- **S4**: new unit test — anchor with no `href` raises `ScreenerLayoutError`.
- **Ruff pin** `>=0.16.2,<0.17`: fixes the gate instability where fresh venvs resolved different ruff minors (0.16 formats md code fences) and the same tree flip-flopped between format-gate pass/fail.
- **S3 refuted, not applied**: the "dead" `cast(str, text)` is load-bearing under strict mypy (bs4 stubs type `anchors[-1]` as `Any`); annotated with a comment instead.

Gates: ruff clean · format clean (161 files) · strict mypy 0 (**63 files**, restored `fincli_api` scope active) · 350 passed · live tier 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLQXaGU1YxBiH2RBP3ZFNV