### PR TITLE
fix(hooks): quality gates resolve tools from project venvs only — never PATH

### DIFF
--- a/.claude/hooks/on-stop.js
+++ b/.claude/hooks/on-stop.js
@@ -10,9 +10,13 @@
  *  5. Dependency audit (pip-audit) — advisory
  *  6. Documentation sync reminder
  *
- * Hardened (2026-08-02):
- *  - Gate tools resolve from the gated tree's .venv (falling back to the main
- *    checkout's venv, then PATH) — hooks inherit a PATH without ruff/mypy/pytest.
+ * Hardened (2026-08-02, venv-only policy 2026-08-12):
+ *  - Gate tools resolve from project venvs ONLY (see utils VENV_ONLY_TOOLS):
+ *    ruff/mypy may come from the gated tree's, the hook checkout's, or the
+ *    main checkout's .venv; pytest must come from the gated tree's own .venv
+ *    (any other venv would import a different tree via its editable install).
+ *    PATH fallback for these tools is refused — a machine-global interpreter
+ *    once masqueraded as a red repo gate.
  *  - Gates run once per GIT TREE that received testable edits — a session that
  *    edited files in a worktree gates that worktree (cwd = tree root), not the
  *    main checkout.
@@ -263,12 +267,16 @@ async function main() {
           skipped.push({ name: check.name, reason: 'no tests collected' });
           continue;
         }
-        if (result.kind === 'unavailable') {
-          // A gate that cannot run must not report green — block with a fix hint.
+        if (result.kind === 'unavailable' && !/PATH fallback is refused/.test(result.output || '')) {
+          // A gate that cannot run must not report green — append a fix hint
+          // to failures that did not come from the venv-only resolver (spawn
+          // errors on a corrupt venv launcher, etc.). Resolver refusals
+          // already carry the full diagnostic, detected by its marker text.
           result.output =
-            `tool '${check.command}' not found (checked ${treeRoot}/.venv and PATH) ` +
-            `— create the venv / pip install -e ".[dev]"` +
-            (result.output ? `\n${result.output}` : '');
+            (result.output ? `${result.output}\n` : '') +
+            `tool '${check.command}' could not run — create the gated tree's venv: ` +
+            'python -m venv .venv && .venv/Scripts/python -m pip install -e ".[dev]" ' +
+            '(.venv/bin/python on POSIX)';
         }
         if (treeLabel) result.output = treeLabel + (result.output || '');
         failures.push(result);

--- a/.claude/hooks/post-edit.js
+++ b/.claude/hooks/post-edit.js
@@ -14,10 +14,12 @@
  * Exit 2 feeds stderr back to Claude — used for lint/format/type errors that
  * survive auto-fix so they get repaired immediately.
  *
- * Hardened (2026-08-02): checks run with cwd = the edited file's own git tree
- * (worktree edits are checked in the worktree) and tools resolve from that
- * tree's .venv (falling back to the main checkout's venv, then PATH). A
- * missing tool is a warning here — the Stop hook blocks on it.
+ * Hardened (2026-08-02, venv-only policy 2026-08-12): checks run with cwd =
+ * the edited file's own git tree (worktree edits are checked in the worktree)
+ * and ruff/mypy resolve from that tree's .venv, falling back to the hook
+ * checkout's or main checkout's .venv — never PATH (see utils
+ * VENV_ONLY_TOOLS). A missing tool is a warning here — the Stop hook blocks
+ * on it.
  *
  * Exit codes:
  *   0 → success (stdout parsed for JSON)

--- a/.claude/hooks/utils.js
+++ b/.claude/hooks/utils.js
@@ -260,16 +260,35 @@ function mainRepoRootOf(treeRoot) {
 }
 
 /**
+ * Gate tools that check or execute project code. These must come from a
+ * project venv — NEVER from PATH: a PATH-resolved interpreter belongs to some
+ * other environment and gates that environment, not this tree (2026-08-12: a
+ * machine-global pytest with an incompatible pytest-asyncio masqueraded as a
+ * red repo gate). `pytest` is stricter still: it IMPORTS the code under test,
+ * and any out-of-tree venv resolves `fincli` through its own editable install
+ * — i.e. it would silently test a DIFFERENT tree — so it may only come from
+ * the gated tree's own venv.
+ */
+const VENV_ONLY_TOOLS = new Set(['ruff', 'mypy', 'pytest']);
+
+/**
  * Resolve a gate tool to the project venv when available (hooks inherit a PATH
- * that usually lacks ruff/mypy/pytest — they live in .venv/Scripts). Tries the
- * gated tree's venv, then this checkout's, then the main checkout's (worktrees
- * share the main venv). Falls back to the bare name (PATH lookup).
+ * that usually lacks ruff/mypy/pytest — they live in .venv/Scripts).
+ *
+ * ruff/mypy try the gated tree's venv, then this checkout's, then the main
+ * checkout's (binary-only tools: any pinned copy judges the tree honestly).
+ * pytest tries the gated tree's venv ONLY (see VENV_ONLY_TOOLS). Venv-only
+ * tools return null when no venv executable exists — callers must surface a
+ * blocking "create the venv" failure instead of falling back to PATH. Other
+ * commands (git, pip-audit) still fall back to the bare name (PATH lookup).
  */
 function resolveTool(file, gateCwd) {
   if (file.includes('/') || file.includes('\\')) return file; // already a path
-  const roots = [gateCwd, PROJECT_ROOT, gateCwd && mainRepoRootOf(gateCwd)].filter(Boolean);
+  const roots = file === 'pytest'
+    ? [gateCwd].filter(Boolean)
+    : [gateCwd, PROJECT_ROOT, gateCwd && mainRepoRootOf(gateCwd)].filter(Boolean);
   const suffixes = process.platform === 'win32'
-    ? [`Scripts/${file}.exe`, `Scripts/${file}`]
+    ? [`Scripts/${file}.exe`, `Scripts/${file}.cmd`, `Scripts/${file}`]
     : [`bin/${file}`];
   for (const root of roots) {
     for (const suffix of suffixes) {
@@ -277,7 +296,7 @@ function resolveTool(file, gateCwd) {
       if (fs.existsSync(candidate)) return candidate;
     }
   }
-  return file; // fall back to PATH
+  return VENV_ONLY_TOOLS.has(file) ? null : file; // PATH fallback: non-gate tools only
 }
 
 function detectService(filePath) {
@@ -364,29 +383,57 @@ function runCommand(name, command, args, options = {}) {
   // Resolve the tool from the gated tree's venv first (hooks inherit a PATH
   // that usually lacks ruff/mypy/pytest — they live in .venv/Scripts).
   let executable = resolveTool(command, cwd);
+
+  // Venv-only gate tool with no venv executable: block honestly instead of
+  // running whatever interpreter PATH happens to expose (see VENV_ONLY_TOOLS).
+  if (executable === null) {
+    const searched = command === 'pytest'
+      ? `${cwd}${path.sep}.venv (pytest must run from the gated tree's own venv — an ` +
+        'out-of-tree venv would import a different tree via its editable install)'
+      : 'the gated tree, hook checkout, and main checkout .venv dirs';
+    return {
+      success: false,
+      name,
+      command: commandText,
+      kind: 'unavailable',
+      status: null,
+      executable: null,
+      output:
+        `gate tool '${command}' has no project-venv executable; searched ${searched}. ` +
+        'PATH fallback is refused for venv-only gate tools. Fix (run inside the gated ' +
+        'tree): python -m venv .venv && .venv/Scripts/python -m pip install -e ".[dev]" ' +
+        '(.venv/bin/python on POSIX)',
+    };
+  }
+
   let executableArgs = args;
   let windowsVerbatimArguments = false;
 
   if (executable === command && process.platform === 'win32') {
-    // No venv hit — fall back to a PATH lookup (handles .cmd/.bat launchers,
-    // which Node refuses to spawn without an explicit cmd.exe wrapper).
+    // No venv hit (non-gate tool) — fall back to a PATH lookup so .cmd/.bat
+    // launchers can be identified and wrapped below.
     const lookup = spawnSync('where.exe', [command], {
       encoding: 'utf8',
       windowsHide: true,
       shell: false,
     });
     const resolved = (lookup.stdout || '').split(/\r?\n/).find(Boolean);
-    if (resolved) {
-      if (/\.(cmd|bat)$/i.test(resolved)) {
-        const quote = value => `"${String(value).replace(/%/g, '%%').replace(/"/g, '""')}"`;
-        const commandLine = `${quote(resolved)} ${args.map(quote).join(' ')}`;
-        executable = process.env.COMSPEC || 'cmd.exe';
-        executableArgs = ['/d', '/s', '/c', `"${commandLine}"`];
-        windowsVerbatimArguments = true;
-      } else {
-        executable = resolved;
-      }
-    }
+    if (resolved) executable = resolved;
+  }
+
+  // The executable actually judging this gate — recorded on every result so a
+  // failure names the interpreter it came from (a PATH/global tool once
+  // masqueraded as a red repo gate; see VENV_ONLY_TOOLS).
+  const resolvedExecutable = executable;
+
+  if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(executable)) {
+    // .cmd/.bat launchers (venv- or PATH-resolved) need an explicit cmd.exe
+    // wrapper — Node refuses to spawn them with shell:false.
+    const quote = value => `"${String(value).replace(/%/g, '%%').replace(/"/g, '""')}"`;
+    const commandLine = `${quote(executable)} ${args.map(quote).join(' ')}`;
+    executable = process.env.COMSPEC || 'cmd.exe';
+    executableArgs = ['/d', '/s', '/c', `"${commandLine}"`];
+    windowsVerbatimArguments = true;
   }
 
   const result = spawnSync(executable, executableArgs, {
@@ -407,6 +454,7 @@ function runCommand(name, command, args, options = {}) {
       command: commandText,
       kind: timedOut ? 'timeout' : 'unavailable',
       status: null,
+      executable: resolvedExecutable,
       output: (output || result.error.message).substring(0, 1200),
     };
   }
@@ -417,13 +465,19 @@ function runCommand(name, command, args, options = {}) {
     command: commandText,
     kind: result.status === 0 ? 'success' : 'non-zero',
     status: result.status,
+    executable: resolvedExecutable,
     output,
   };
 }
 
 function formatCommandFailure(result) {
+  // Name the interpreter/binary that produced the verdict — a red gate from
+  // the wrong environment must be diagnosable from the failure text alone.
+  const via = result.executable && result.executable !== result.command.split(' ')[0]
+    ? `\nvia: ${result.executable}`
+    : '';
   const detail = result.output ? `\n${result.output}` : '';
-  return `${result.name} failed (${result.command}; ${result.kind})${detail}`;
+  return `${result.name} failed (${result.command}; ${result.kind})${via}${detail}`;
 }
 
 // ──────────────────────────────────────────────

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@ A thin, newest-first index of shipped streams. Phase status and direction live
 in `docs/THESIS.md`; implementation detail lives in the linked spec or closeout.
 Per-merge history does not belong in `CLAUDE.md`.
 
+- 2026-08-12 · Hook gate integrity · gate tools (ruff/mypy/pytest) resolve from project venvs ONLY — pytest pinned to the gated tree's own venv, PATH-interpreter fallback refused with an actionable blocking diagnostic, and every gate failure names the executable that judged it; ruff pinned `>=0.16.2,<0.17` (same stream, PR #21) · `.claude/hooks/utils.js` + `docs/FEEDBACK-LOG.md`
 - 2026-08-11 · `scrape_link` on `POST /screens` · accept a direct Finviz URL on the HTTP API, mirroring the CLI's `--scrape-link` (mutually exclusive with `filters`, no inventory validation, host-allowlisted to finviz.com); also grows the filter inventory with `fa_sales3years` and the missing `ta_perf2` 3/5/10-year value codes · `docs/pendingwork/2026-07-25-scrape-link-http-api.md`
 - 2026-08-11 · Parser hardening · fix GitHub issue #14 (redesigned-layout ticker cells duplicating their first letter) and close MAJOR #4 (missing-table HTML silently coercing to a 200 empty result) via `ScreenerLayoutError` + the `js-screener-body-empty` empty-result discriminator · GitHub issue #14
 - 2026-08-11 · Observability · request-id correlation, JSON logs, health triad + `/metrics` on the HTTP API; CLI `run_id` (Singleton-logger correlation deferred — THESIS "Beyond Phase 4") · `docs/plans/2026-07-14-observability.md`

--- a/docs/FEEDBACK-LOG.md
+++ b/docs/FEEDBACK-LOG.md
@@ -230,3 +230,35 @@ textual merge tools pick one side and the loss is invisible because gates
 diff the merged `[tool.mypy]`/`[tool.coverage]` sections against BOTH parents
 before concluding gates are intact. A spec/plan claiming a scope choice is
 "unchanged" is a snapshot, not an invariant — re-verify at merge time.
+
+---
+
+### 2026-08-12 — Quality gates must never run a PATH interpreter; pytest must run from the gated tree's own venv
+
+**What:** The Stop hook's tool resolver fell back to PATH when no project venv
+executable was found. On this machine the global `C:\Python312` pytest carried
+an incompatible `pytest-asyncio`, so a Stop gate reported a red repo (import
+errors collecting `tests/e2e/api`) while the actual project — under its own
+venv — was fully green (350 passed, 94.45% coverage). Symmetrically dangerous
+in reverse: a healthy global interpreter could report GREEN for a broken tree.
+A second, subtler hazard: pytest from any OTHER venv (main checkout's, another
+worktree's) imports `fincli` through THAT venv's editable install — it silently
+tests a different tree than the one being gated.
+
+**Why:** A gate's verdict is only meaningful if the tool that produced it
+belongs to the tree being judged. PATH is machine state, not project state.
+
+**How to apply:** `.claude/hooks/utils.js` now enforces venv-only resolution
+for ruff/mypy/pytest (`VENV_ONLY_TOOLS`): ruff/mypy may come from the gated
+tree's / hook checkout's / main checkout's venv (they never import the tree;
+honest from any venv now that ruff AND mypy are minor-pinned in dev deps);
+pytest only from the gated tree's own venv.
+No venv → blocking "create the venv" failure, never a PATH run. Every gate
+failure now prints `via: <executable>` so a wrong-environment verdict is
+diagnosable from the failure text alone. Fresh worktrees therefore need
+`python -m venv .venv && .venv/Scripts/python -m pip install -e ".[dev]"`
+before their first gate run — that is the supported way to make worktree
+gates pass. Hook regression test: PATH shims present + venv absent must block
+without invoking any gate tool
+(`tests/integration/hooks/test_quality_gate_hooks.py`).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dev = [
     # worktree venvs resolving different ruff minors made the same tree pass
     # one gate run and fail the next (2026-08-12 burndown session).
     "ruff>=0.16.2,<0.17",
-    "mypy>=1.10",
+    # Same rationale as the ruff pin: gate verdicts must not drift with the
+    # mypy minor a given venv happened to resolve (see FEEDBACK-LOG 2026-08-12).
+    "mypy>=2.3,<2.4",
     "pytest>=8",
     "pytest-cov>=5",
     "types-beautifulsoup4",

--- a/tests/integration/hooks/conftest.py
+++ b/tests/integration/hooks/conftest.py
@@ -21,6 +21,7 @@ class HookSandbox:
     hook_dir: Path
     command_log: Path
     environment: dict[str, str]
+    tool_runner: Path
 
     def write_file(self, relative_path: str, content: str) -> Path:
         file_path = self.project_root / relative_path
@@ -131,27 +132,49 @@ if (
         encoding="utf-8",
     )
 
-    for tool in ("git", "mypy", "pip-audit", "pytest", "ruff"):
-        if os.name == "nt":
-            wrapper = bin_dir / f"{tool}.cmd"
-            wrapper.write_text(
-                '@set "COV_CORE_SOURCE="\n'
-                '@set "COV_CORE_CONFIG="\n'
-                '@set "COV_CORE_DATAFILE="\n'
-                f'@"{sys.executable}" "{runner}" "{tool}" %*\n',
-                encoding="utf-8",
-            )
-        else:
-            wrapper = bin_dir / tool
-            wrapper.write_text(
-                "#!/bin/sh\n"
-                "unset COV_CORE_SOURCE COV_CORE_CONFIG COV_CORE_DATAFILE\n"
-                f'exec "{sys.executable}" "{runner}" "{tool}" "$@"\n',
-                encoding="utf-8",
-            )
-            wrapper.chmod(0o755)
+    # Non-gate tools (git, pip-audit) resolve via PATH; write them here. The
+    # venv-only gate tools (ruff/mypy/pytest) are written into the sandbox
+    # project's .venv by ``install_venv_tools`` — the hooks refuse PATH
+    # fallback for those, so a PATH shim alone would never be invoked.
+    for tool in ("git", "pip-audit"):
+        write_tool_wrapper(bin_dir, tool, runner)
 
     return bin_dir, command_log
+
+
+def write_tool_wrapper(directory: Path, tool: str, runner: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    if os.name == "nt":
+        wrapper = directory / f"{tool}.cmd"
+        wrapper.write_text(
+            '@set "COV_CORE_SOURCE="\n'
+            '@set "COV_CORE_CONFIG="\n'
+            '@set "COV_CORE_DATAFILE="\n'
+            f'@"{sys.executable}" "{runner}" "{tool}" %*\n',
+            encoding="utf-8",
+        )
+    else:
+        wrapper = directory / tool
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            "unset COV_CORE_SOURCE COV_CORE_CONFIG COV_CORE_DATAFILE\n"
+            f'exec "{sys.executable}" "{runner}" "{tool}" "$@"\n',
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+
+def install_venv_tools(project_root: Path, runner: Path, *tools: str) -> Path:
+    """Write gate-tool shims into ``<project_root>/.venv`` (Scripts/ or bin/).
+
+    Mirrors where the hooks' venv-only resolver looks for ruff/mypy/pytest —
+    the sandbox must provide them exactly there, since PATH fallback for
+    those tools is refused by design.
+    """
+    venv_bin = project_root / ".venv" / ("Scripts" if os.name == "nt" else "bin")
+    for tool in tools:
+        write_tool_wrapper(venv_bin, tool, runner)
+    return venv_bin
 
 
 @pytest.fixture
@@ -167,6 +190,10 @@ def hook_sandbox(tmp_path: Path) -> HookSandbox:
     (project_root / "singleton.py").write_text("", encoding="utf-8")
 
     bin_dir, command_log = _write_fake_toolchain(tmp_path)
+    runner = bin_dir / "tool_runner.py"
+    # Venv-only gate tools live in the sandbox project's own .venv — the hooks
+    # refuse PATH fallback for ruff/mypy/pytest, so PATH shims would be ignored.
+    install_venv_tools(project_root, runner, "ruff", "mypy", "pytest")
     environment = os.environ.copy()
     environment.update(
         {
@@ -176,4 +203,4 @@ def hook_sandbox(tmp_path: Path) -> HookSandbox:
             "PATH": os.pathsep.join((str(bin_dir), environment["PATH"])),
         }
     )
-    return HookSandbox(project_root, hook_dir, command_log, environment)
+    return HookSandbox(project_root, hook_dir, command_log, environment, runner)

--- a/tests/integration/hooks/test_quality_gate_hooks.py
+++ b/tests/integration/hooks/test_quality_gate_hooks.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import shutil
 from typing import TYPE_CHECKING
 
 import pytest
+from conftest import write_tool_wrapper
 
 if TYPE_CHECKING:
     from .conftest import HookSandbox
@@ -144,6 +146,62 @@ def test_post_edit_clean_python_file_exits_zero(hook_sandbox: HookSandbox) -> No
         ["format", "--check"],
     ]
     assert [call["args"] for call in calls if call["tool"] == "mypy"] == [[str(edited_file)]]
+
+
+def test_on_stop_refuses_path_gate_tools_when_venv_is_missing(
+    hook_sandbox: HookSandbox,
+) -> None:
+    """Venv-only gate tools must never run from PATH.
+
+    Regression pin for the 2026-08-12 incident where a machine-global pytest
+    (with an incompatible plugin) masqueraded as a red repo gate. PATH shims
+    for ruff/mypy/pytest ARE present here; the project venv is deleted. The
+    hook must block with the create-the-venv diagnostic WITHOUT invoking any
+    of the three — proving the PATH fallback is gone, not merely deprioritized.
+    """
+    _testable_session(hook_sandbox)
+    path_bin = hook_sandbox.tool_runner.parent
+    for tool in ("ruff", "mypy", "pytest"):
+        write_tool_wrapper(path_bin, tool, hook_sandbox.tool_runner)
+    shutil.rmtree(hook_sandbox.project_root / ".venv")
+
+    result = hook_sandbox.run("on-stop.js", {})
+
+    assert result.returncode == 2
+    assert "no project-venv executable" in result.stderr
+    assert "PATH fallback is refused" in result.stderr
+    gate_calls = [
+        call for call in hook_sandbox.command_calls() if call["tool"] in {"ruff", "mypy", "pytest"}
+    ]
+    assert gate_calls == []
+
+
+def test_on_stop_pytest_requires_the_gated_trees_own_venv(
+    hook_sandbox: HookSandbox,
+) -> None:
+    """pytest may not fall back to another venv; ruff/mypy may.
+
+    Pins the differential policy: a gated tree (own ``.git/``, no ``.venv``)
+    is seeded while the hook checkout's venv shims exist. ruff/mypy resolve
+    through the fallback chain and run; pytest — which would import a
+    DIFFERENT tree via that venv's editable install — must be refused with
+    the gated-tree-only diagnostic instead.
+    """
+    tree = hook_sandbox.project_root.parent / "gated_tree"
+    (tree / ".git").mkdir(parents=True)
+    edited_file = tree / "fincli" / "example.py"
+    edited_file.parent.mkdir(parents=True)
+    edited_file.write_text("value: int = 1\n", encoding="utf-8")
+    hook_sandbox.seed_session(edited_file)
+
+    result = hook_sandbox.run("on-stop.js", {})
+
+    assert result.returncode == 2
+    assert "no project-venv executable" in result.stderr
+    assert "gated tree's own venv" in result.stderr
+    tools = {call["tool"] for call in hook_sandbox.command_calls()}
+    assert {"ruff", "mypy"} <= tools
+    assert "pytest" not in tools
 
 
 def test_post_edit_markdown_skips_code_gates(hook_sandbox: HookSandbox) -> None:


### PR DESCRIPTION
## Incident

The Stop hook's gate-tool resolver fell back to PATH when no project venv executable was found. The machine-global `C:\Python312` pytest carries plugins the project never chose (an incompatible `pytest-asyncio`), so a Stop gate reported a **red repo** while the project under its own venv was fully green (350 passed / 94.45%). The reverse masking — a healthy global interpreter reporting green for a broken tree — was equally possible. A second, subtler hazard: pytest from any *other* venv imports `fincli` through **that** venv's editable install, silently testing a different tree than the one being gated.

## Fix

- **`VENV_ONLY_TOOLS` = {ruff, mypy, pytest}** — PATH is never consulted for these. No venv → honest blocking failure with the exact `python -m venv …` fix hint (this is now the supported way to make **worktree gates pass**: give the worktree its own venv).
- **pytest is gated-tree-venv-only**; ruff/mypy may fall back to the hook/main checkout's venv (binary-only tools, now that both are minor-pinned — mypy pinned `>=2.3,<2.4` in this PR, ruff pinned in #21).
- **Transparency**: every gate failure prints `via: <executable>` — a wrong-environment verdict is diagnosable from the failure text alone.
- Uniform `.cmd`/`.bat` wrapping for venv- and PATH-resolved launchers; stale hook docstrings corrected.
- **Tests**: sandbox shims moved into the sandbox project's `.venv` (realistic resolution path); two new regression pins — (1) PATH shims present + venv deleted → block with **zero** gate-tool invocations; (2) the pytest-vs-ruff/mypy differential policy via a second gated tree.
- Machine-level companion fix (not in diff): global `pytest-asyncio` upgraded to 1.4.0.

## Gates

ruff clean · format clean (161 files) · strict mypy 0 (63 files) · **352 passed** / coverage 94.17% · hook tests 12/12.

## Review

REVIEWER verdict: APPROVE_WITH_NITS — all six findings applied (differential-policy test, hint-append on spawn errors, post-edit docstring, mypy pin, POSIX hint wording, public helper rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLQXaGU1YxBiH2RBP3ZFNV